### PR TITLE
ai-brain: thread mapping cache and better formatting of messages

### DIFF
--- a/internal/source/ai-brain/brain.go
+++ b/internal/source/ai-brain/brain.go
@@ -90,6 +90,10 @@ func (s *Source) Stream(ctx context.Context, in source.StreamInput) (source.Stre
 	instance := newAssistant(cfg, s.log, streamOutput.Event, kubeConfigPath)
 	s.instances.Store(sourceName, instance)
 
+	// Start assistant thread mapping cache cleanup. Technically the cache won't
+	// grow that much because botkube agent will be eventually restarted anyway.
+	go instance.cache.Cleanup()
+
 	s.log.Infof("Setup successful for source configuration %q", sourceName)
 	return streamOutput, nil
 }

--- a/internal/source/ai-brain/cache.go
+++ b/internal/source/ai-brain/cache.go
@@ -1,0 +1,64 @@
+package aibrain
+
+import (
+	"sync"
+	"time"
+)
+
+type cache struct {
+	m   sync.Map
+	ttl time.Duration
+}
+
+type entry struct {
+	threadID   string
+	expireTime time.Time
+}
+
+func newCache(ttl time.Duration) *cache {
+	return &cache{
+		m:   sync.Map{},
+		ttl: ttl,
+	}
+}
+
+func (c *cache) Set(messageID, threadID string) {
+	c.m.Store(messageID, &entry{
+		threadID:   threadID,
+		expireTime: time.Now().Add(c.ttl),
+	})
+}
+
+func (c *cache) Get(messageID string) (string, bool) {
+	item, ok := c.m.Load(messageID)
+	if !ok {
+		return "", false
+	}
+
+	e, ok := item.(*entry)
+	if !ok || time.Now().After(e.expireTime) {
+		c.m.Delete(messageID)
+		return "", false
+	}
+
+	return e.threadID, true
+}
+
+func (c *cache) Delete(messageID string) {
+	c.m.Delete(messageID)
+}
+
+func (c *cache) Cleanup() {
+	ticker := time.NewTicker(c.ttl / 16)
+	defer ticker.Stop()
+
+	for range ticker.C {
+		c.m.Range(func(k interface{}, v interface{}) bool {
+			e, ok := v.(*entry)
+			if !ok || time.Now().After(e.expireTime) {
+				c.m.Delete(k)
+			}
+			return true
+		})
+	}
+}

--- a/internal/source/ai-brain/response.go
+++ b/internal/source/ai-brain/response.go
@@ -50,7 +50,6 @@ var (
 	reTeamsItalic        = regexp.MustCompile(`_([^_]+)_`)
 	reTeamsStrikethrough = regexp.MustCompile(`~~([^~]+)~~`)
 	reTeamsHeading       = regexp.MustCompile(`^#+ (.*)$`)
-	reTeamsLink          = regexp.MustCompile(`\[([^\]]+)]\(([^)]+)\)`) // Basic link support
 	reTeamsImageLink     = regexp.MustCompile(`!\[([^\]]+)]\(([^)]+)\)`)
 )
 


### PR DESCRIPTION
<!-- Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

This is the next iteration in our journey to build a smarter botkube bot. I've added an internal cache to map messaging platform message id (think thread) to an OpenAI thread. The bot will be able to keep conversational context, which drastically improves UX.

I also added a hacky way of converting markdown markup text to slack compatible text markup. Need to somehow distinguish between slack and teams messages. I believe @mszostok has an idea.

## Description

Changes proposed in this pull request:

- ai-brain: implement thread mapping with an internal cache
- ai-brain: try to convert markdown to slack and teams markup

Here is what it looks like, see screenshots below:
![image](https://github.com/kubeshop/botkube-cloud-plugins/assets/1308018/a17ae733-a55b-4f77-8586-3bfa5f390310)

Better formatting
![image](https://github.com/kubeshop/botkube-cloud-plugins/assets/1308018/e5a3fb8e-4946-4594-b6ca-81ca2082993f)


## Related issue(s)

<!-- If you refer to a particular issue, provide its number.
To close the issue after the pull request merge, use `Resolves #123` or `Fixes #123`.
Otherwise, use `See also #123` or just `#123`. -->

Related https://github.com/kubeshop/botkube-cloud/issues/843
