### PR TITLE
Improve markdown formatting for Slack and Teams

### DIFF
--- a/internal/source/ai-brain/response_test.go
+++ b/internal/source/ai-brain/response_test.go
@@ -1,0 +1,33 @@
+package aibrain
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"gotest.tools/v3/golden"
+)
+
+// TestConvertProperlyAIAnswer tests that we can convert proper AI answer to Slack or Teams message format.
+//
+// To update golden files run:
+//
+//	go  test ./internal/source/ai-brain/... -run=TestConvertProperlyAIAnswer -update
+func TestConvertProperlyAIAnswer(t *testing.T) {
+	// given
+	md, err := os.ReadFile(filepath.Join("testdata", t.Name(), "aiAnswer.md"))
+	require.NoError(t, err)
+
+	// Slack
+	out := msgAIAnswer("42.42", string(md))
+	assertGolden(t, out.Sections[0].Base.Body.Plaintext, "slack.golden.md")
+
+	// Teams
+	out = msgAIAnswer("19:d25cbf7cbfa74d22b42a2918452e1153@thread.tacv2", string(md))
+	assertGolden(t, out.BaseBody.Plaintext, "teams.golden.md")
+}
+
+func assertGolden(t *testing.T, actual, goldenPath string) {
+	golden.Assert(t, actual, filepath.Join(t.Name(), goldenPath))
+}

--- a/internal/source/ai-brain/testdata/TestConvertProperlyAIAnswer/aiAnswer.md
+++ b/internal/source/ai-brain/testdata/TestConvertProperlyAIAnswer/aiAnswer.md
@@ -1,0 +1,79 @@
+## Found Issues
+
+The issue you're facing is due to a missing secret named `ngin`. Secrets in Kubernetes are used to store and handle sensitive information, such as passwords, OAuth tokens, ssh keys, etc. The specific error indicates that a pod is trying to use a secret called `ngin` that doesn’t exist in the cluster. Here’s a simple step-by-step guide on how to fix it:
+
+1. **Identify the Missing Secret Requirement:**
+
+   >  Ensure that the name **"ngin"** is correct. Sometimes, a typo in the pod configuration or secret name can cause such issues.
+
+2. Create the Secret:
+   If the secret is indeed missing `##` and you know the data that should be within it (like a token or password), you will need to create the secret. This can be done using the kubectl command line. For example, if you're creating a generic secret, you might use:
+
+    ```shell
+    kubectl create secret generic ngin --from-literal=key=value -n test
+    ```
+
+    Replace key and value with the actual data you need to store. The -n test specifies the namespace (test in this case) where the secret will be created. Adjust as necessary.
+3. **Update the Pod or Deployment Configuration:**
+   If the secret name was incorrect due to a typo in your pod or deployment configuration, you should update the relevant YAML file to correct the secret name and then apply the changes. For example:
+
+   ```yaml
+      apiVersion: v1
+      kind: Pod
+      metadata:
+        name: your-pod-name
+      spec:
+        containers:
+        - name: your-container-name
+          image: nginx
+          env:
+            - name: SECRET_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: ngin  # Make sure this matches the correct secret name
+                  key: key
+   ```
+
+If you had to update your configuration, apply the changes:
+
+```
+kubectl apply -f your-deployment.yaml
+```
+
+### Ecosystem and Community
+
+![logo](https://raw.githubusercontent.com/kubeshop/botkube/main/branding/logos/botkube-black-32x32.png)
+
+_Kubernetes_ has a ~~large~~, rapidly growing `ecosystem`. Kubernetes' services, support, and tools are widely available.
+
+> Kubernetes has entered the chat
+> Intelligent Kubernetes Monitoring & Troubleshooting Platform
+
+[Botkube](https://botkube.io/)
+
+
+| Tables   |      Are      |  Cool |
+|----------|:-------------:|------:|
+| col 1 is |  left-aligned | $1600 |
+| col 2 is |    centered   |   $12 |
+| col 3 is | right-aligned |    $1 |
+
+
+### Notes
+
+This message includes:
+- link
+- image
+- text 
+  - italic
+  - bold
+  - strike
+- multi-line code block
+  - with syntax
+  - without syntax
+- single code block
+- bullet list
+- numbered list
+- headers
+- blockquote
+- table

--- a/internal/source/ai-brain/testdata/TestConvertProperlyAIAnswer/slack.golden.md
+++ b/internal/source/ai-brain/testdata/TestConvertProperlyAIAnswer/slack.golden.md
@@ -1,0 +1,79 @@
+*Found Issues*
+
+The issue you're facing is due to a missing secret named `ngin`. Secrets in Kubernetes are used to store and handle sensitive information, such as passwords, OAuth tokens, ssh keys, etc. The specific error indicates that a pod is trying to use a secret called `ngin` that doesn’t exist in the cluster. Here’s a simple step-by-step guide on how to fix it:
+
+1. *Identify the Missing Secret Requirement:*
+
+   >  Ensure that the name *"ngin"* is correct. Sometimes, a typo in the pod configuration or secret name can cause such issues.
+
+2. Create the Secret:
+   If the secret is indeed missing `##` and you know the data that should be within it (like a token or password), you will need to create the secret. This can be done using the kubectl command line. For example, if you're creating a generic secret, you might use:
+
+    ```
+    kubectl create secret generic ngin --from-literal=key=value -n test
+    ```
+
+    Replace key and value with the actual data you need to store. The -n test specifies the namespace (test in this case) where the secret will be created. Adjust as necessary.
+3. *Update the Pod or Deployment Configuration:*
+   If the secret name was incorrect due to a typo in your pod or deployment configuration, you should update the relevant YAML file to correct the secret name and then apply the changes. For example:
+
+   ```
+      apiVersion: v1
+      kind: Pod
+      metadata:
+        name: your-pod-name
+      spec:
+        containers:
+        - name: your-container-name
+          image: nginx
+          env:
+            - name: SECRET_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: ngin  # Make sure this matches the correct secret name
+                  key: key
+   ```
+
+If you had to update your configuration, apply the changes:
+
+```
+kubectl apply -f your-deployment.yaml
+```
+
+*Ecosystem and Community*
+
+<https://raw.githubusercontent.com/kubeshop/botkube/main/branding/logos/botkube-black-32x32.png|logo>
+
+_Kubernetes_ has a ~large~, rapidly growing `ecosystem`. Kubernetes' services, support, and tools are widely available.
+
+> Kubernetes has entered the chat
+> Intelligent Kubernetes Monitoring & Troubleshooting Platform
+
+<https://botkube.io/|Botkube>
+
+
+| Tables   |      Are      |  Cool |
+|----------|:-------------:|------:|
+| col 1 is |  left-aligned | $1600 |
+| col 2 is |    centered   |   $12 |
+| col 3 is | right-aligned |    $1 |
+
+
+*Notes*
+
+This message includes:
+- link
+- image
+- text 
+  - italic
+  - bold
+  - strike
+- multi-line code block
+  - with syntax
+  - without syntax
+- single code block
+- bullet list
+- numbered list
+- headers
+- blockquote
+- table

--- a/internal/source/ai-brain/testdata/TestConvertProperlyAIAnswer/teams.golden.md
+++ b/internal/source/ai-brain/testdata/TestConvertProperlyAIAnswer/teams.golden.md
@@ -1,0 +1,81 @@
+**Found Issues**
+
+The issue you're facing is due to a missing secret named `ngin`. Secrets in Kubernetes are used to store and handle sensitive information, such as passwords, OAuth tokens, ssh keys, etc. The specific error indicates that a pod is trying to use a secret called `ngin` that doesn’t exist in the cluster. Here’s a simple step-by-step guide on how to fix it:
+
+1. **Identify the Missing Secret Requirement:**
+
+   >  Ensure that the name **"ngin"** is correct. Sometimes, a typo in the pod configuration or secret name can cause such issues.
+
+2. Create the Secret:
+   If the secret is indeed missing `##` and you know the data that should be within it (like a token or password), you will need to create the secret. This can be done using the kubectl command line. For example, if you're creating a generic secret, you might use:
+
+    ```shell
+    kubectl create secret generic ngin --from-literal=key=value -n test
+    ```
+
+    Replace key and value with the actual data you need to store. The -n test specifies the namespace (test in this case) where the secret will be created. Adjust as necessary.
+3. **Update the Pod or Deployment Configuration:**
+   If the secret name was incorrect due to a typo in your pod or deployment configuration, you should update the relevant YAML file to correct the secret name and then apply the changes. For example:
+
+   ```yaml
+      apiVersion: v1
+      kind: Pod
+      metadata:
+        name: your-pod-name
+      spec:
+        containers:
+        - name: your-container-name
+          image: nginx
+          env:
+            - name: SECRET_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: ngin  # Make sure this matches the correct secret name
+                  key: key
+   ```
+
+If you had to update your configuration, apply the changes:
+
+```
+kubectl apply -f your-deployment.yaml
+```
+
+**Ecosystem and Community**
+
+[logo](https://raw.githubusercontent.com/kubeshop/botkube/main/branding/logos/botkube-black-32x32.png)
+
+_Kubernetes_ has a ~~large~~, rapidly growing `ecosystem`. Kubernetes' services, support, and tools are widely available.
+
+> Kubernetes has entered the chat
+> Intelligent Kubernetes Monitoring & Troubleshooting Platform
+
+[Botkube](https://botkube.io/)
+
+
+| Tables   |      Are      |  Cool |
+|----------|:-------------:|------:|
+| col 1 is |  left-aligned | $1600 |
+| col 2 is |    centered   |   $12 |
+| col 3 is | right-aligned |    $1 |
+
+
+**Notes**
+
+This message includes:
+- link
+- image
+- text 
+  - italic
+  - bold
+  - strike
+- multi-line code block
+  - with syntax
+  - without syntax
+- single code block
+- bullet list
+- numbered list
+- headers
+- blockquote
+- table
+
+~AI-generated content may be incorrect.~


### PR DESCRIPTION
<!-- Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

## Description

Changes proposed in this pull request:

- Improve markdown formatting for Slack and Teams. There as till some glitches but with a given timebox I couldn't achieve more.

## Testing


1. Checkout the `kubeshop/botkube-cloud` https://github.com/kubeshop/botkube-cloud/pull/947
2. Create cluster: `k3d cluster create labs`
7. Run `PLUGIN_TARGETS='ai,ai-brain' make build-plugins-single`
8. Start server `make serve-local-plugins`
9. Start control-plane with local cloud plugins:
    ```yaml
      botkubeCloud:
        type: Public
        botkubeVersionConstraint: ">= 1.9.0" # this will cover RCs too  
        url: http://host.k3d.internal:3010/botkube.yaml
    
    ```
10. Create Instance with AI enabled, run some prompts


### Screenshots

I tested that by sending message with all format options:


<table>
<tr>
<td> Slack </td> <td> Teams </td>
</tr>
<tr>
<td>

<img width="696" alt="Screenshot 2024-03-12 at 09 29 33" src="https://github.com/kubeshop/botkube-cloud-plugins/assets/17568639/de35e120-c8d6-4af4-a9d3-326aab7df746">


</td>
<td>
<img width="987" alt="Screenshot 2024-03-12 at 09 30 12" src="https://github.com/kubeshop/botkube-cloud-plugins/assets/17568639/52e98557-7b73-4353-9799-e4e1c3a3f191">


</td>
</tr>
</table>

## Related issue(s)

Fix  https://github.com/kubeshop/botkube-cloud/issues/946

Blocked by https://github.com/kubeshop/botkube-cloud/pull/947 - if we will merge it without `backend-cloud` changes it will stop sending AI responses.