### PR TITLE
Fix formatting for Teams AI responses

### DIFF
--- a/internal/source/ai-brain/assistant.go
+++ b/internal/source/ai-brain/assistant.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"net/http"
 	"os"
-	"strings"
 	"time"
 
 	"github.com/kubeshop/botkube-cloud-plugins/internal/otelx"
@@ -276,7 +275,6 @@ func (i *assistant) handleStatusCompleted(ctx context.Context, run openai.Run, p
 			continue
 		}
 
-		c.Text.Value = strings.ReplaceAll(c.Text.Value, "%", "%%")
 		i.out <- source.Event{
 			Message: msgAIAnswer(p.MessageID, c.Text.Value),
 		}

--- a/internal/source/ai-brain/response.go
+++ b/internal/source/ai-brain/response.go
@@ -120,6 +120,10 @@ func msgAIAnswer(messageID, text string) api.Message {
 		}
 	}
 
+	// the Sections.Base.Body is rendered by engine using `fmt.Sprintf` so we need to escape '%' returned
+	// from the AI to prevent it from being interpreted as formatting.
+	text = strings.ReplaceAll(text, "%", "%%")
+
 	// messageID is set only for Teams or Slack, for others like Discord, Mattermost, we keep the original formatting
 	if messageID != "" {
 		text = markdownToSlack(text)
@@ -152,7 +156,9 @@ func markdownToSlack(text string) string {
 
 func markdownToTeams(text string) string {
 	text = mdHeadings.ReplaceAllString(text, "**$1**")
-	text = mdImages.ReplaceAllString(text, "[$1]($2)")     // get rid of ! to define it as a link instead of image
-	text += "\n~AI-generated content may be incorrect.~\n" // add the warning
+	text = mdImages.ReplaceAllString(text, "[$1]($2)") // get rid of ! to define it as a link instead of image
+
+	// https://learn.microsoft.com/en-us/microsoftteams/platform/task-modules-and-cards/cards/cards-format?tabs=adaptive-md%2Cdesktop%2Cconnector-html#newlines-for-adaptive-cards
+	text += "\n\n~AI-generated content may be incorrect.~\n" // add the warning
 	return text
 }

--- a/internal/source/ai-brain/testdata/TestConvertProperlyAIAnswer/teams.golden.md
+++ b/internal/source/ai-brain/testdata/TestConvertProperlyAIAnswer/teams.golden.md
@@ -78,4 +78,5 @@ This message includes:
 - blockquote
 - table
 
+
 ~AI-generated content may be incorrect.~


### PR DESCRIPTION
<!-- Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

## Description

Changes proposed in this pull request:

-  Fix formatting for Teams AI responses


## Testing

1. Just run the control-plane with plugins from this repo as defined here: https://github.com/kubeshop/botkube-cloud-plugins?tab=readme-ov-file#development

Test the `%` sign:
<img width="1172" alt="Screenshot 2024-04-18 at 13 35 15" src="https://github.com/kubeshop/botkube-cloud-plugins/assets/17568639/c9e7c0d3-cf2e-4941-b9fa-29c6deda70d3">

Test the `'` sign + observe the footer formatting:
<img width="1176" alt="Screenshot 2024-04-18 at 13 35 18" src="https://github.com/kubeshop/botkube-cloud-plugins/assets/17568639/2b50e0a1-f1ed-48d2-b607-f5c4d098863a">



## Related issue(s)

- https://github.com/kubeshop/botkube-cloud/issues/994