### PR TITLE
executor/ai: implement cluster scan prompting

### DIFF
--- a/cmd/executor/ai/main.go
+++ b/cmd/executor/ai/main.go
@@ -77,7 +77,7 @@ func (e *AIFace) Execute(_ context.Context, in executor.ExecuteInput) (executor.
 	aiBrainWebhookURL := fmt.Sprintf("%s/%s", in.Context.IncomingWebhook.BaseSourceURL, cfg.AIBrainSourceName)
 
 	body, err := json.Marshal(aibrain.Payload{
-		Prompt:    strings.TrimPrefix(in.Command, pluginName),
+		Prompt:    strings.TrimSpace(strings.TrimPrefix(in.Command, pluginName)),
 		MessageID: in.Context.Message.ParentActivityID,
 	})
 	if err != nil {


### PR DESCRIPTION
<!-- Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

## Description

This is part of https://github.com/kubeshop/botkube-cloud/issues/1062. The cluster scan prompt will need more tuning for sure, but I don't want to spend much more time on that. I have already been trying so many variations of the prompt. It would be great for someone else to play with it and give us suggestions how to improve it. Or maybe we go ahead and get early feedback from users and iterate?

As you can see the implementation is actually very simple, which is nice. We can always make it mode complicated - that's easy.

Changes proposed in this pull request:

- executor/ai: implement cluster scan prompting

## Related issue(s)

<!-- If you refer to a particular issue, provide its number.
To close the issue after the pull request merge, use `Resolves #123` or `Fixes #123`.
Otherwise, use `See also #123` or just `#123`. -->
