### PR TITLE
ai-brain: move summary section to the top

### DIFF
--- a/internal/source/ai-brain/assistant.go
+++ b/internal/source/ai-brain/assistant.go
@@ -40,6 +40,14 @@ const (
 Scan the Kubernetes cluster for critical issues that could significantly impact the cluster's health, stability, or security.
 Focus on problems that may not be immediately apparent through events or standard monitoring.
 
+Provide a concise overview of the scan results, including the total number of
+critical issues found. If there were no issues found for a specific check, do
+not include that section in the report. List the Kubernetes objects directly
+affected by the issue. Make sure that your checks are relevant to the current
+state of the cluster, do not include resources that no longer exist.
+
+Summary section needs to be at the top of the report, followed by specific checks.
+
 Specific Checks:
 
 Pod Health:
@@ -56,12 +64,6 @@ Check for misconfigured network policies that could expose sensitive services.
 Networking:
 Identify pods or services experiencing significant network latency or packet loss.
 Check for network partitions or connectivity issues between critical components.
-
-Provide a concise overview of the scan results, including the total number of
-critical issues found. If there were no issues found for a specific check, do
-not include that section in the report. List the Kubernetes objects directly
-affected by the issue. Make sure that your checks are relevant to the current
-state of the cluster, do not include resources that no longer exist.
 
 Additional Guidance for the LLM Agent:
 


### PR DESCRIPTION
<!-- Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

## Description
I do not have a lot of issues currently in my local setup, so the report is rather bleak, but the summary section is at the top now.

![image](https://github.com/kubeshop/botkube-cloud-plugins/assets/1308018/42e283ad-bab8-4142-a2b3-7eef6acab6dd)

Changes proposed in this pull request:

- ai-brain: move summary section to the top

## Related issue(s)

<!-- If you refer to a particular issue, provide its number.
To close the issue after the pull request merge, use `Resolves #123` or `Fixes #123`.
Otherwise, use `See also #123` or just `#123`. -->
