### PR TITLE
Create PoC for a custom vector store

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -215,3 +215,5 @@ require (
 	sigs.k8s.io/kustomize/kyaml v0.14.3-0.20230601165947-6ce0bf390ce3 // indirect
 	sigs.k8s.io/structured-merge-diff/v4 v4.4.1 // indirect
 )
+
+replace github.com/sashabaranov/go-openai => github.com/kubeshop/go-openai v0.0.0-20240529092413-08c3654597da

--- a/go.sum
+++ b/go.sum
@@ -669,6 +669,8 @@ github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
 github.com/kr/text v0.2.0/go.mod h1:eLer722TekiGuMkidMxC/pM04lWEeraHUUmBw8l2grE=
 github.com/kubeshop/botkube v0.13.1-0.20240527133334-a3f727e2a30f h1:vnOhS1p8eJkxSiqc0ms7NSNLwRmxbK58k4Ig1DX7b6U=
 github.com/kubeshop/botkube v0.13.1-0.20240527133334-a3f727e2a30f/go.mod h1:OZeY4kLDrVQlaGxCE3XnTX8UUUhSpENIZ41PmBVIePg=
+github.com/kubeshop/go-openai v0.0.0-20240529092413-08c3654597da h1:g0kbZXkado8Vv0IIS8Yech8zy11SKmSET+KkodeRKdk=
+github.com/kubeshop/go-openai v0.0.0-20240529092413-08c3654597da/go.mod h1:lj5b/K+zjTSFxVLijLSTDZuP7adOgerWeFyZLUhAKRg=
 github.com/leodido/go-urn v1.2.0/go.mod h1:+8+nEpDfqqsY+g338gtMEUOtuK+4dEMhiQEgxpxOKII=
 github.com/leodido/go-urn v1.2.4 h1:XlAE/cm/ms7TE/VMVoduSpNBoyc2dOxHs5MZSwAN63Q=
 github.com/leodido/go-urn v1.2.4/go.mod h1:7ZrI8mTSeBSHl/UaRyKQW1qZeMgak41ANeCNaVckg+4=
@@ -823,8 +825,6 @@ github.com/ryanuber/columnize v2.1.0+incompatible/go.mod h1:sm1tb6uqfes/u+d4ooFo
 github.com/ryanuber/go-glob v1.0.0/go.mod h1:807d1WSdnB0XRJzKNil9Om6lcp/3a0v4qIHxIXzX/Yc=
 github.com/sanity-io/litter v1.5.5 h1:iE+sBxPBzoK6uaEP5Lt3fHNgpKcHXc/A2HGETy0uJQo=
 github.com/sanity-io/litter v1.5.5/go.mod h1:9gzJgR2i4ZpjZHsKvUXIRQVk7P+yM3e+jAF7bU2UI5U=
-github.com/sashabaranov/go-openai v1.23.0 h1:KYW97r5yc35PI2MxeLZ3OofecB/6H+yxvSNqiT9u8is=
-github.com/sashabaranov/go-openai v1.23.0/go.mod h1:lj5b/K+zjTSFxVLijLSTDZuP7adOgerWeFyZLUhAKRg=
 github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529/go.mod h1:DxrIzT+xaE7yg65j358z/aeFdxmN0P9QXhEzd20vsDc=
 github.com/sergi/go-diff v1.3.1 h1:xkr+Oxo4BOQKmkn/B9eMK0g5Kg/983T9DqqPHwYqD+8=
 github.com/sergi/go-diff v1.3.1/go.mod h1:aMJSSKb2lpPvRNec0+w3fl7LP9IOFzdc9Pa4NFbPK1I=

--- a/hack/assistant-setup/content-custom/cli-readme.md
+++ b/hack/assistant-setup/content-custom/cli-readme.md
@@ -1,0 +1,95 @@
+![Mongo Seeding](https://raw.githubusercontent.com/pkosiec/mongo-seeding/main/docs/assets/logo.png)
+
+# Mongo Seeding CLI
+
+[![npm version](https://badge.fury.io/js/mongo-seeding-cli.svg)](https://npmjs.org/package/mongo-seeding-cli) [![Build Status](https://github.com/pkosiec/mongo-seeding/actions/workflows/branch.yaml/badge.svg)](https://github.com/pkosiec/mongo-seeding/actions) [![codecov](https://codecov.io/gh/pkosiec/mongo-seeding/branch/main/graph/badge.svg?flag=cli)](https://codecov.io/gh/pkosiec/mongo-seeding) [![David](https://img.shields.io/david/pkosiec/mongo-seeding.svg?path=cli)]() [![David](https://img.shields.io/david/dev/pkosiec/mongo-seeding.svg?path=cli)]() [![install size](https://packagephobia.now.sh/badge?p=mongo-seeding-cli)](https://packagephobia.now.sh/result?p=mongo-seeding-cli)
+
+The ultimate CLI tool for populating your MongoDB database :rocket:
+
+Define MongoDB documents in JSON, JavaScript or even TypeScript file(s). Import them with command line interface.
+
+## Installation
+
+To install the app, run the following command:
+
+```bash
+npm install -g mongo-seeding-cli
+```
+
+## Usage
+
+1. Follow the [tutorial](https://github.com/pkosiec/mongo-seeding/blob/main/docs/import-data-definition.md) to define documents and collections to import.
+1. In order to seed your database with data from current directory using default configuration, run the following command:
+
+   ```bash
+   seed
+   ```
+
+1. You can specify custom settings with command line parameters. The following example imports data from `./example/data` directory using MongoDB connection URI `mongodb://127.0.0.1:27017/mydb` with option to drop database before import:
+
+   ```bash
+   seed -u 'mongodb://127.0.0.1:27017/mydb' --drop-database ./example/data
+   ```
+
+   You can also use environmental variables to configure the CLI. For example:
+
+   ```bash
+   DB_URI='mongodb://127.0.0.1:27017/mydb' DROP_DATABASE=true seed ./example/data
+   ```
+
+   Full configuration options are described in [Configuration](#configuration) section.
+
+## Configuration
+
+You can configure data import with command line parameters or environmental variables.
+
+> **Note:** Command line parameters have always a higher priority over environmental variables.
+
+## Command line parameters
+
+You can use the following parameters while using `seed` tool:
+
+| Name                           | Default Value     | Description                                                                                                                                                                                             |
+| ------------------------------ | ----------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `{PATH}`                       | current directory | Path to directory containing import data                                                                                                                                                                |
+| `--db-uri {URI}` or `-u {URI}` | _`undefined`_     | If defined, the URI will be used for establishing connection to database, ignoring values defined via other `db-*` parameters (e.g. `db-name`, `db-host`, etc.)                                         |
+| `--db-protocol {DB_PROTOCOL}`  | `mongodb`         | MongoDB database protocol                                                                                                                                                                               |
+| `--db-host {DB_HOST}`          | `127.0.0.1`       | MongoDB database host                                                                                                                                                                                   |
+| `--db-port {DB_PORT}`          | `27017`           | MongoDB database port                                                                                                                                                                                   |
+| `--db-name {DB_NAME}`          | `database`        | Name of the database                                                                                                                                                                                    |
+| `--db-username {DB_USERNAME}`  | _`undefined`_     | Username for connecting with database that requires authentication                                                                                                                                      |
+| `--db-password {DB_PASSWORD}`  | _`undefined`_     | Password for connecting with database that requires authentication                                                                                                                                      |
+| `--db-options`                 | _`undefined`_     | [MongoDB connection options](https://docs.mongodb.com/manual/reference/connection-string/) in a form of multiple `{key}={value}` values, separated by semicolon. For example: `ssl=true;maxPoolSize=50` |
+| `--drop-database`              | `false`           | Drops entire database before data import                                                                                                                                                                |
+| `--drop-collections`           | `false`           | Drops every collection which is being imported                                                                                                                                                          |
+| `--remove-all-documents`       | `false`           | Delete all documents from every collection that is being imported                                                                                                                                       |
+| `--replace-id`                 | `false`           | Replaces `id` property with `_id` for every document during data import                                                                                                                                 |
+| `--set-timestamps`             | `false`           | Sets `createdAt` and `updatedAt` timestamps for every document during data import                                                                                                                       |
+| `--reconnect-timeout`          | `10000`           | Maximum time in milliseconds of waiting for successful MongoDB connection                                                                                                                               |
+| `--ejson-parse-canonical-mode` | `false`           | Enables [EJSON Canonical Mode](https://docs.mongodb.com/manual/reference/mongodb-extended-json/) for all parsed `.json` files. By default the EJSON Relaxed mode is enabled.                            |
+| `--transpile-only`             | `false`           | Disables type checking on TypeScript files import. This option vastly improves performance of TypeScript data import                                                                                    |
+| `--silent` or `-s`             | `false`           | Disables printing logging of Mongo Seeding status to standard output                                                                                                                                    |
+| `--help` or `-h`               | n/a               | Help                                                                                                                                                                                                    |
+
+## Environmental variables
+
+You can use the following environmental variables while using `seed` tool:
+
+| Name                         | Default Value | Description                                                                                                                                                                                              |
+| ---------------------------- | ------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `DB_URI`                     | _`undefined`_ | If defined, the URI is used for establishing connection to database, ignoring values given in `DB_*` environmental variables (e.g. `DB_HOST`, `DB_PORT`, etc.).                                          |
+| `DB_HOST`                    | `127.0.0.1`   | MongoDB database host                                                                                                                                                                                    |
+| `DB_PORT`                    | `27017`       | MongoDB database port                                                                                                                                                                                    |
+| `DB_NAME`                    | `database`    | Name of the database                                                                                                                                                                                     |
+| `DB_USERNAME`                | _`undefined`_ | Username for connecting with database that requires authentication                                                                                                                                       |
+| `DB_PASSWORD`                | _`undefined`_ | Password for connecting with database that requires authentication                                                                                                                                       |
+| `DB_OPTIONS`                 | _`undefined`_ | [MongoDB connection options](https://docs.mongodb.com/manual/reference/connection-string/) in a form of multiple `{key}={value}` values, separated by semicolon. For example: `ssl=true;maxPoolSize=50`. |
+| `DROP_DATABASE`              | `false`       | Drops entire database before data import                                                                                                                                                                 |
+| `DROP_COLLECTIONS`           | `false`       | Drops every collection which is being imported                                                                                                                                                           |
+| `REMOVE_ALL_DOCUMENTS`       | `false`       | Delete all documents from every collection that is being imported                                                                                                                                        |
+| `REPLACE_ID`                 | `false`       | Replaces `id` property with `_id` for every document during import; useful for ORMs                                                                                                                      |
+| `SET_TIMESTAMPS`             | `false`       | Sets `createdAt` and `updatedAt` timestamps for every document during data import                                                                                                                        |
+| `RECONNECT_TIMEOUT`          | `10000`       | Maximum time in milliseconds of waiting for successful MongoDB connection                                                                                                                                |
+| `EJSON_PARSE_CANONICAL_MODE` | `false`       | Enables [EJSON Canonical Mode](https://docs.mongodb.com/manual/reference/mongodb-extended-json/) for all parsed `.json` files. By default the EJSON Relaxed mode is enabled.                             |
+| `TRANSPILE_ONLY`             | `false`       | Disables type checking on TypeScript files import. This option vastly improves performance of TypeScript data import                                                                                     |
+| `SILENT`                     | `false`       | Disables printing logging of Mongo Seeding status to standard output                                                                                                                                     |

--- a/hack/assistant-setup/content-custom/contributing.md
+++ b/hack/assistant-setup/content-custom/contributing.md
@@ -1,0 +1,23 @@
+# Contributing
+
+Github is used to host code, track issues and feature requests, as well as accept pull requests.
+
+## Tooling
+
+This project uses [Volta](https://github.com/volta-cli/volta) to manage Node.js version. It is recommended to install it before starting development.
+
+## Development process
+
+[Github flow](https://guides.github.com/introduction/flow/index.html) is used as a development process. This means that all changes are done by creating pull requests. Bringing a code change to this project should be executed as follows:
+
+1. Fork this repository.
+1. Make your changes. Do not forget about tests.
+1. Squash your changes to single commit. Write a concise commit message in imperative mode as described [here](https://chris.beams.io/posts/git-commit/).
+1. Rebase your changes to latest `main`.
+1. Create a pull request.
+
+Pull requests are very welcome. However, if you want to add a new feature, please discuss your ideas first using Github issues.
+
+## License
+
+When you submit code changes, your submissions are understood to be under the same [MIT License](http://choosealicense.com/licenses/mit/) that covers the project.

--- a/hack/assistant-setup/content-custom/core-readme.md
+++ b/hack/assistant-setup/content-custom/core-readme.md
@@ -1,0 +1,296 @@
+![Mongo Seeding](https://raw.githubusercontent.com/pkosiec/mongo-seeding/main/docs/assets/logo.png)
+
+# Mongo Seeding
+
+[![npm version](https://badge.fury.io/js/mongo-seeding.svg)](https://npmjs.org/package/mongo-seeding) [![Build Status](https://github.com/pkosiec/mongo-seeding/actions/workflows/branch.yaml/badge.svg)](https://github.com/pkosiec/mongo-seeding/actions) [![codecov](https://codecov.io/gh/pkosiec/mongo-seeding/branch/main/graph/badge.svg?flag=core)](https://codecov.io/gh/pkosiec/mongo-seeding) [![David](https://img.shields.io/david/pkosiec/mongo-seeding.svg?path=core)]() [![David](https://img.shields.io/david/dev/pkosiec/mongo-seeding.svg?path=core)]() [![install size](https://packagephobia.now.sh/badge?p=mongo-seeding)](https://packagephobia.now.sh/result?p=mongo-seeding)
+
+The ultimate solution for populating your MongoDB database. Define the data in JavaScript or JSON files. Import collections and documents!
+
+## Table of contents
+
+<!-- toc -->
+
+- [Installation](#installation)
+- [Usage](#usage)
+- [API description](#api-description)
+  - [`constructor(partialConfig?)`](#constructorpartialconfig)
+  - [`readCollectionsFromPath(path, partialOptions?)`](#readcollectionsfrompathpath-partialoptions)
+  - [`import(collections, partialConfig?)`](#importcollections-partialconfig)
+- [Debug output](#debug-output)
+
+<!-- tocstop -->
+
+## Installation
+
+To install the app, run the following command:
+
+```bash
+npm install mongo-seeding --save
+```
+
+## Usage
+
+1.  Import the `Seeder` class:
+
+    ```javascript
+    const { Seeder } = require('mongo-seeding');
+    ```
+
+1.  Define a partial configuration object. The object will be merged with the default config object (see [Configuration](#configuration) section). Therefore, you can specify only properties, which should override the default values, for example:
+
+    ```javascript
+    const config = {
+      database: {
+        host: '127.0.0.1',
+        port: 27017,
+        name: 'mydatabase',
+      },
+      dropDatabase: true,
+    };
+    ```
+
+    Instead of database configuration object, you can also provide database connection URI to the `database` property:
+
+    ```javascript
+    const config = {
+      database: 'mongodb://127.0.0.1:27017/mydatabase',
+      dropDatabase: true,
+    };
+    ```
+
+1.  Instantiate `Seeder` class:
+
+    ```javascript
+    const seeder = new Seeder(config);
+    ```
+
+1.  **(OPTIONAL)** To read MongoDB collections from disk, firstly follow the [tutorial](https://github.com/pkosiec/mongo-seeding/blob/main/docs/import-data-definition.md) in order to define documents and collections to import. Next, read them using `readCollectionsFromPath` method:
+
+    ```javascript
+    const path = require('path');
+    const collections = seeder.readCollectionsFromPath(
+      path.resolve('./your/path'),
+    );
+    ```
+
+1.  Seed your database:
+
+    - with `async/await`, for example:
+
+      ```javascript
+      try {
+        await seeder.import(collections);
+      } catch (err) {
+        // Handle errors
+      }
+      // Do whatever you want after successful import
+      ```
+
+    - with raw promises:
+
+      ```javascript
+      seeder
+        .import(collections)
+        .then(() => {
+          // Do whatever you want after successful import
+        })
+        .catch((err) => {
+          // Handle errors
+        });
+      ```
+
+See an [**import data example**](https://github.com/pkosiec/mongo-seeding/blob/main/examples/import-data) for a sample Node.js application utilizing the library.
+
+## API description
+
+The `Seeder` class contains the following methods.
+
+### `constructor(partialConfig?)`
+
+Constructs a new `Seeder` instance and loads configuration for data import.
+
+**Configuration**
+
+You can override any default configuration property by passing partial config object to the `Seeder` constructor. The object is merged with the default configuration object. To use all default settings, simply omit the constructor argument (`new Seeder()`).
+
+The following snippet represents the type definition of `Seeder` config with all available properties:
+
+```typescript
+/**
+ * Defines configuration for database seeding.
+ */
+export interface SeederConfig {
+  /**
+   * Database connection URI or configuration object.
+   */
+  database: SeederDatabaseConfig;
+  /**
+   * Maximum time of waiting for successful MongoDB connection in milliseconds. Ignored when `mongoClientOptions` are passed.
+   */
+  databaseReconnectTimeout: number;
+  /**
+   * Drops entire database before import.
+   */
+  dropDatabase: boolean;
+  /**
+   * Drops collection before importing it.
+   */
+  dropCollections: boolean;
+  /**
+   * Deletes all documents from every collection that is being imported.
+   */
+  removeAllDocuments: boolean;
+  /**
+   * Optional MongoDB client options.
+   */
+  mongoClientOptions?: MongoClientOptions;
+  /**
+   * Optional MongoDB collection write options.
+   */
+  bulkWriteOptions?: BulkWriteOptions;
+}
+
+export interface SeederDatabaseConfigObject {
+  protocol: string;
+  host: string;
+  port: number;
+  name: string;
+  username?: string;
+  password?: string;
+  options?: SeederDatabaseConfigObjectOptions; // see all options for Database Connection URI: https://docs.mongodb.com/manual/reference/connection-string
+}
+
+export type SeederDatabaseConfigObjectOptions = {
+  [key: string]: string;
+};
+```
+
+In order to configure database connection, specify connection URI for `database` property or assign a partial `SeederDatabaseConfigObject` object, overriding necessary properties.
+
+**Default configuration**:
+
+The default configuration object is as follows:
+
+```javascript
+const defaultConfig = {
+  database: {
+    protocol: 'mongodb',
+    host: '127.0.0.1',
+    port: 27017,
+    name: 'database',
+    username: undefined,
+    password: undefined,
+  },
+  databaseReconnectTimeout: 10000,
+  dropDatabase: false,
+  dropCollections: false,
+  mongoClientOptions: undefined,
+  bulkWriteOptions: undefined,
+};
+```
+
+### `readCollectionsFromPath(path, partialOptions?)`
+
+Populates collections and their documents from given path. The path has to contain import data structure described [here](https://github.com/pkosiec/mongo-seeding/blob/main/docs/import-data-definition.md).
+
+**Options**
+
+You can specify an optional partial options object for this method, which will be merged with default configuration object. See the interface of the options, which describes all possible options:
+
+```typescript
+/**
+ * Defines collection reading configuration.
+ */
+export interface SeederCollectionReadingOptions {
+  /**
+   * Files extensions that should be imported
+   */
+  extensions: string[];
+
+  /**
+   * Options for parsing EJSON files with `.json` extension
+   */
+  ejsonParseOptions?: EJSONOptions;
+
+  /**
+   * Optional transformer functions that can be used to modify collection data before import.
+   */
+  transformers: ((collection: SeederCollection) => SeederCollection)[];
+}
+```
+
+For example, you may provide the following options object:
+
+```typescript
+const collectionReadingOptions = {
+  extensions: ['ts', 'js', 'cjs', 'json'],
+  ejsonParseOptions: {
+    relaxed: false,
+  },
+  transformers: [Seeder.Transformers.replaceDocumentIdWithUnderscoreId],
+};
+
+const collections = seeder.readCollectionsFromPath(
+  path.resolve('./your/path'),
+  collectionReadingOptions,
+);
+```
+
+Transform function is a simple function in a form of `(collection: SeederCollection) => SeederCollection`. It means that you can manipulate collections after reading them from disk. `SeederCollection` is defined as follows:
+
+```typescript
+interface SeederCollection {
+  name: string;
+  documents: object[];
+}
+```
+
+There is two built-in transform functions:
+
+- **`Seeder.Transformers.replaceDocumentIdWithUnderscoreId`**, which replaces `id` field with `_id` property for every document in collection.
+
+- **`Seeder.Transformers.setTimestamps`**, which sets `createdAt` and `updatedAt` timestamps for every document in collection.
+
+**Default options**
+
+The default options object is as follows:
+
+```typescript
+const defaultCollectionReadingConfig: SeederCollectionReadingConfig = {
+  extensions: ['json', 'js', 'cjs'],
+  ejsonParseOptions: {
+    relaxed: true,
+  },
+  transformers: [],
+};
+```
+
+### `import(collections, partialConfig?)`
+
+This method connects to a database and imports all provided collections. `collections` argument type is an array of `SeederCollection` type, which is defined as follows:
+
+```typescript
+interface SeederCollection {
+  name: string;
+  documents: object[];
+}
+```
+
+**Configuration**
+
+You can provide additional `partialConfig` argument in a form of `Seeder` partial configuration object - the same used in the constructor. It is an easy way to change the configuration for one single data import. The configuration object will be merged with provided configuration from constructor and default config.
+
+## Debug output
+
+In order to see debug output, set environmental variable `DEBUG` to value `mongo-seeding` before starting your Node.js app:
+
+```bash
+DEBUG=mongo-seeding node yourapp/index.js
+```
+
+You can also set it programmatically before requiring `mongo-seeding`:
+
+```javascript
+process.env.DEBUG = 'mongo-seeding';
+const { Seeder } = require('mongo-seeding');
+```

--- a/hack/assistant-setup/content-custom/docker-readme.md
+++ b/hack/assistant-setup/content-custom/docker-readme.md
@@ -1,0 +1,103 @@
+![Mongo Seeding](https://raw.githubusercontent.com/pkosiec/mongo-seeding/main/docs/assets/logo.png)
+
+# Mongo Seeding Docker Image
+
+[![Build Status](https://github.com/pkosiec/mongo-seeding/actions/workflows/branch.yaml/badge.svg)](https://github.com/pkosiec/mongo-seeding/actions)
+
+The ultimate Docker image for populating your MongoDB database :rocket:
+
+Define MongoDB documents in JSON, JavaScript or even TypeScript file(s). Import them with an easy-to-use Docker image.
+
+## Usage
+
+1. Follow the [tutorial](../docs/import-data-definition.md) to define documents and collections to import.
+1. Pull the latest stable version of Mongo Seeding image.
+
+   ```bash
+   docker pull ghcr.io/pkosiec/mongo-seeding:{versionNumber}
+   ```
+
+   Check the version number in GitHub releases.
+
+1. Run the image. Mount your directory with input data with `-v {source}:{destination}` parameter. Specify workspace which is a directory containing data import structure. Usually it will be the same directory:
+
+   ```bash
+   docker run --rm --network=host -v /absolute/path/to/data/:/absolute/path/to/data/ -w /absolute/path/to/data ghcr.io/pkosiec/mongo-seeding
+   ```
+
+   Sometimes, in import data files you would like to `import` or `require` other dependencies, like helper functions defined somewhere else or external libraries. In order to resolve them properly in Docker container, you have to to mount the root directory of your project. As a working directory, define exact path for a directory that contains just the import data.
+
+   ```bash
+   docker run --rm --network=host -v /absolute/path/to/project/:/absolute/path/to/project -w /absolute/path/to/project/import-data/ ghcr.io/pkosiec/mongo-seeding
+   ```
+
+1. Configure seeding with environmental variables. See the following example:
+
+   ```bash
+    docker run --rm --network=host -v /absolute/path/to/examples/:/absolute/path/to/data/ -w /absolute/path/to/data/ -e DB_URI='mongodb://127.0.0.1:27017/mydbname' -e DROP_DATABASE=true ghcr.io/pkosiec/mongo-seeding
+   ```
+
+   See [Configuration](#configuration) section for details.
+
+## Configuration
+
+The Docker image is basically a containerized CLI tool. Therefore, to configure the project, use environmental variables described in [Environmental Variables](../cli/README.md#environmental-variables) section of the CLI tool. Specify them with `-e {key}={value}` parameters.
+
+## Override image entrypoint and command
+
+As with every Docker container, you can override the [entrypoint](https://docs.docker.com/engine/reference/run/#entrypoint-default-command-to-execute-at-runtime) and the [command](https://docs.docker.com/engine/reference/run/#cmd-default-command-or-options).
+
+For example, to prevent Mongo Seeding Docker container from exiting after seeding, use the following command:
+
+```bash
+docker run --rm --entrypoint="sh" ghcr.io/pkosiec/mongo-seeding -c 'seed; sleep infinity'
+```
+
+## Docker image customization
+
+You can prepare a customized Docker image for data import. It allows you to prepare image that contains import data inside and is already configured for your needs.
+
+1. Prepare Dockerfile:
+
+   ```
+   FROM ghcr.io/pkosiec/mongo-seeding
+
+   #
+   # Copy sample data
+   #
+
+   COPY ./data /import-data
+
+   #
+   # Set environmental variables (optional)
+   #
+
+   ENV DB_HOST 127.0.0.1
+   ENV DB_NAME mydbname
+   ENV DB_PORT 27017
+   ENV DROP_DATABASE true
+   ENV REPLACE_ID true
+   ENV SET_TIMESTAMPS true
+
+   #
+   # Set default workspace to not specify it every time the image is ran
+   #
+
+   WORKDIR /import-data
+   ```
+
+   If in any import data file there is an external dependency, copy not only data import files, but also `package.json` with `package-lock.json` and run `npm install` during image build.
+
+1. Build the image:
+
+   ```bash
+   docker build -t custom-mongo-seeding .
+   ```
+
+1. Run the image
+
+   ```bash
+   docker run --rm --network="host" custom-mongo-seeding
+   ```
+
+See [**examples**](../examples) directory for an example of custom Docker image.

--- a/hack/assistant-setup/content-custom/example-custom-docker-image.md
+++ b/hack/assistant-setup/content-custom/example-custom-docker-image.md
@@ -1,0 +1,32 @@
+# Custom Docker image
+
+This example presents how to build your own Docker image based on [Mongo Seeding Docker image](../../docker-image). It allows you to prepare image that contains import data inside and is already configured for your needs.
+
+## Prerequisites
+
+In order to run this example, you have to install the following tools:
+
+- [Docker](https://docker.com)
+
+## Usage
+
+1. After cloning the repository, navigate to this directory.
+1. To build the image, run:
+
+   ```bash
+   docker build -t custom-mongo-seeding .
+   ```
+
+1. Run MongoDB database with Docker on local machine on port 30000:
+
+   ```bash
+   docker run --rm -p 30000:27017 mongo:latest
+   ```
+
+1. Run the custom data import image with the following command:
+
+   ```bash
+   docker run --rm --network="host" custom-mongo-seeding
+   ```
+
+1. You should see that all MongoDB documents from `sample-data/data` directory have been successfully imported. The database name and port have been configured with default values of environmental variables set in custom Docker image.

--- a/hack/assistant-setup/content-custom/example-import-data-ts.md
+++ b/hack/assistant-setup/content-custom/example-import-data-ts.md
@@ -1,0 +1,109 @@
+# Example of TypeScript import data
+
+This example shows how to define import data in TypeScript files with model validation enabled. There are two collections defined: `categories` and `posts`.
+Data import files are prepared to show multiple possibilities of TypeScript data definition. In some data import files there are used helper methods defined in `helpers` directory.
+
+## Prerequisites
+
+In order to run this example, it's recommended to install the following tools:
+
+- [Docker](https://docker.com) (optional) - to run MongoDB and Mongo Seeding Docker Image
+- [NodeJS with NPM](https://nodejs.org) (optional) - to run JavaScript example
+
+## Preparations
+
+1.  After cloning the repository, navigate to this directory.
+1.  Run MongoDB on your local machine on port 27017. The recommended way is to use Docker:
+
+    ```bash
+    docker run --rm -p 27017:27017 mongo
+    ```
+
+1.  Navigate to the `./example` directory.
+1.  To install all needed dependencies of import data, run the following command:
+
+    ```bash
+    npm install
+    ```
+
+## Import data
+
+In order to import the sample data, use one of Mongo Seeding tools. The following instructions will result in sample data import to `testing` database. The database will be dropped before import.
+
+### JavaScript library
+
+To import data from TypeScript files, the application, that utilizes Mongo Seeding library has to have TypeScript execution support configured. This tutorial shows how to setup it properly.
+
+1.  Initialize a new Node.js project in this directory (folder, which contains this Readme file) with the command:
+
+    ```
+    npm init -y
+    ```
+
+1.  Create a new `index.js` file in the same directory with the following content:
+
+    ```javascript
+    require('ts-node').register();
+    const path = require('path');
+    const { Seeder } = require('mongo-seeding');
+
+    const config = {
+      database: {
+        name: 'testing',
+      },
+      dropDatabase: true,
+    };
+    const seeder = new Seeder(config);
+    const collections = seeder.readCollectionsFromPath(
+      path.resolve('./example/data'),
+      {
+        extensions: ['js', 'json', 'ts'],
+        transformers: [Seeder.Transformers.replaceDocumentIdWithUnderscoreId],
+      },
+    );
+
+    seeder
+      .import(collections)
+      .then(() => {
+        console.log('Success');
+      })
+      .catch((err) => {
+        console.log('Error', err);
+      });
+    ```
+
+1.  To install all required dependencies used in your `index.js` application, run the command:
+
+    ```bash
+    npm install mongo-seeding typescript ts-node --save
+    ```
+
+1.  Turn on the debug output from `mongo-seeding` library and run the newly created app to import data:
+
+    ```bash
+    DEBUG=mongo-seeding node index.js
+    ```
+
+To see the full description of the JS library usage, read the **[Readme](../../core/README.md)** file of the Mongo Seeding.
+
+### CLI
+
+Make sure that you have the [Mongo Seeding CLI](../../cli) installed. Then, run the following command from this directory (folder, which contains this Readme file):
+
+```bash
+seed --drop-database --replace-id --set-timestamps --db-name testing ./example/data
+```
+
+To see the full description of the CLI usage, read the **[Readme](../../cli/README.md)** file of the Mongo Seeding CLI.
+
+### Docker image
+
+Execute the following command:
+
+```bash
+docker run --rm --network="host" -e DB_NAME=testing -e REPLACE_ID=true SET_TIMESTAMPS=true -e DROP_DATABASE=true -v /absolute/path/to/examples/import-data-ts/example/:/absolute/path/to/examples/import-data-ts/example/ -w /absolute/path/to/examples/import-data-ts/example/data pkosiec/mongo-seeding
+```
+
+Replace `/absolute/path/to/` with your absolute path to this cloned repository.
+
+To read more how to run the Docker image with all configuration parameters, read the **[Readme](../../docker-image/README.md)** file of the Mongo Seeding Docker image.

--- a/hack/assistant-setup/content-custom/example-import-data.md
+++ b/hack/assistant-setup/content-custom/example-import-data.md
@@ -1,0 +1,105 @@
+# Example of import data
+
+This example shows how to define import data in JavaScript and JSON files. There are two collections defined: `categories` and `posts`.
+Data import files are prepared to show multiple possibilities of data definition. In some data import files there are used helper methods defined in `helpers` directory.
+
+## Prerequisites
+
+In order to run this example, it's recommended to install the following tools:
+
+- [Docker](https://docker.com) (optional) - to run MongoDB and Mongo Seeding Docker Image
+- [NodeJS with NPM](https://nodejs.org) (optional) - to run JavaScript example
+
+## Preparations
+
+1.  After cloning the repository, navigate to this directory.
+1.  Run MongoDB on your local machine on port 27017. The recommended way is to use Docker:
+
+    ```bash
+    docker run --rm -p 27017:27017 mongo
+    ```
+
+1.  Navigate to the `./example` directory.
+1.  To install all needed dependencies of import data, run the following command:
+
+    ```bash
+    npm install
+    ```
+
+## Import data
+
+In order to import the sample data, use one of Mongo Seeding tools. The following instructions will result in sample data import to `testing` database. The database will be dropped before import.
+
+### JavaScript library
+
+1.  Initialize a new Node.js project in this directory (folder, which contains this Readme file) with the command:
+
+    ```
+    npm init -y
+    ```
+
+1.  Create a new `index.js` file in the same directory with the following content:
+
+    ```javascript
+    const path = require('path');
+    const { Seeder } = require('mongo-seeding');
+
+    const config = {
+      database: {
+        name: 'testing',
+      },
+      dropDatabase: true,
+    };
+    const seeder = new Seeder(config);
+    const collections = seeder.readCollectionsFromPath(
+      path.resolve('./example/data'),
+      {
+        transformers: [Seeder.Transformers.replaceDocumentIdWithUnderscoreId],
+      },
+    );
+
+    seeder
+      .import(collections)
+      .then(() => {
+        console.log('Success');
+      })
+      .catch((err) => {
+        console.log('Error', err);
+      });
+    ```
+
+1.  To install all dependencies used in your `index.js` application, run the command:
+
+    ```bash
+    npm install mongo-seeding --save
+    ```
+
+1.  Turn on the debug output from `mongo-seeding` library and run the newly created app to import data:
+
+    ```bash
+    DEBUG=mongo-seeding node index.js
+    ```
+
+To see the full description of the JS library usage, read the **[Readme](../../core/README.md)** file of the Mongo Seeding.
+
+### CLI
+
+Make sure that you have the [Mongo Seeding CLI](../../cli) installed. Then, run the following command from this directory (folder, which contains this Readme file):
+
+```bash
+seed --drop-database --replace-id --set-timestamps --db-name testing ./example/data
+```
+
+To see the full description of the CLI usage, read the **[Readme](../../cli/README.md)** file of the Mongo Seeding CLI.
+
+### Docker image
+
+Execute the following command:
+
+```bash
+docker run --rm --network="host" -e DB_NAME=testing -e REPLACE_ID=true SET_TIMESTAMPS=true -e DROP_DATABASE=true -v /absolute/path/to/examples/import-data/example/:/absolute/path/to/examples/import-data/example/ -w /absolute/path/to/examples/import-data/example/data ghcr.io/pkosiec/mongo-seeding
+```
+
+Replace `/absolute/path/to/` with your absolute path to this cloned repository.
+
+To read more how to run the Docker image with all configuration parameters, read the **[Readme](../../docker-image/README.md)** file of the Mongo Seeding Docker image.

--- a/hack/assistant-setup/content-custom/example-mongoose-express.md
+++ b/hack/assistant-setup/content-custom/example-mongoose-express.md
@@ -1,0 +1,305 @@
+# How to use Mongo Seeding with Mongoose and Express
+
+This example shows you how to import data from mongoose model to Mongodb database.
+There are three models defined, `customers`, `menus`, and `orders`.
+
+## Prerequisites
+
+In order to run this example, install the following tools:
+
+- [NodeJS with NPM](https://nodejs.org)
+- [Mongoose](https://mongoosejs.com/)
+- [Express](https://expressjs.com/)
+- [MongoDB](https://mongodb.com) database
+- [Mongo Seeding CLI](../../cli/README.md)
+
+## Prepare data model
+
+Create the following Mongoose models:
+
+**Customer model**
+
+```js
+const mongoose = require('mongoose');
+
+const CustomerShema = mongoose.Schema({
+  name: String,
+  lastname: String,
+  email: {
+    type: String,
+    unique: true,
+  },
+  password: String,
+});
+
+module.exports = mongoose.model('Customer', CustomerShema);
+```
+
+**Menu model**
+
+```js
+const mongoose = require('mongoose');
+
+const MenuSchema = mongoose.Schema({
+  name: String,
+  price: Number,
+  category: {
+    type: String,
+    enum: ['firstCourse', 'mainCourse'],
+    default: 'mainCourse',
+  },
+});
+
+module.exports = mongoose.model('Menu', MenuSchema);
+```
+
+**Order model**
+
+```js
+const mongoose = require('mongoose');
+const Menu = require('./menu');
+const Customer = require('./customer');
+
+const Schema = mongoose.Schema;
+
+const OrderSchema = Schema({
+  order_detail: [{ type: Schema.Types.ObjectId, ref: Menu }],
+  customer: { type: Schema.Types.ObjectId, ref: Customer },
+  date: Date,
+});
+
+module.exports = mongoose.model('Order', OrderSchema);
+```
+
+## Define proper directory structure
+
+To learn how to structure import data, see the [Import data definition guide](../../docs/import-data-definition.md). In this example the following directory structure is used:
+
+> **NOTE:** A good practice is to use plural names for MongoDB collections.
+
+```js
+   .
+   ├── data // Root directory
+   │    ├── 1-customers // `customers`collection
+   │    │   └── customer.json
+   │    ├── 2-menus // `menus` collection
+   │    │   └── menu.json
+   │    └── 3-orders // `orders` collection
+   │        └── order.json
+```
+
+## Define import data
+
+The collection directory can contain multiple files with different extensions (JSON, JS or TS). In this example JSON files are used.
+
+Create the following files:
+
+**customer.json**
+
+```json
+[
+  {
+    "_id": { "$oid": "5e8508ea69a10e42d07414be" },
+    "name": "Emma",
+    "lastname": "Watson",
+    "email": "emma@watson.com",
+    "password": "$2a$10$hhn8vSvl6rpv42undbkQ.O5XIdIJkujyqQWqKIxRJgLQYCGlM/6rW"
+  },
+  {
+    "_id": { "$oid": "5e850bd669a10e42d07414c0" },
+    "name": "Pablo",
+    "lastname": "Picasso",
+    "email": "pablo@picasso.com",
+    "password": "$2a$10$hhn8vSvl6rpv42undbkQ.O5XIdIJkujyqQWqKIxRJgLQYCGlM/6rW"
+  }
+]
+```
+
+**menu.json**
+
+```json
+[
+  {
+    "_id": { "$oid": "5e6066bea0403411bc4a3333" },
+    "name": "Ceviche",
+    "price": 18.0,
+    "category": "firstCourse"
+  },
+  {
+    "_id": { "$oid": "5e6066e9a0403411bc4a3334" },
+    "name": "Tacos",
+    "price": 18.0,
+    "category": "firstCourse"
+  },
+  {
+    "_id": { "$oid": "5e606408dc8aec3040688a86" },
+    "name": "Lomo saltado",
+    "price": 20.0,
+    "category": "mainCourse"
+  },
+  {
+    "_id": { "$oid": "5e60650ea0403411bc4a332f" },
+    "name": "Stew",
+    "price": 20.0,
+    "category": "mainCourse"
+  }
+]
+```
+
+**order.json**
+
+```json
+[
+  {
+    "_id": { "$oid": "5e8186aa5d750a38e4260fcc" },
+    "order_detail": [
+      { "$oid": "5e606408dc8aec3040688a86" },
+      { "$oid": "5e6066bea0403411bc4a3333" }
+    ],
+    "customer": { "$oid": "5e8508ea69a10e42d07414be" },
+    "date": { "$date": { "$numberLong": "1583902800000" } }
+  },
+  {
+    "_id": { "$oid": "5e8187d53eda1f3a20d887e1" },
+    "order_detail": [
+      { "$oid": "5e60650ea0403411bc4a332f" },
+      { "$oid": "5e6066e9a0403411bc4a3334" }
+    ],
+    "customer": { "$oid": "5e850bd669a10e42d07414c0" },
+    "date": { "$date": { "$numberLong": "1583902800000" } }
+  }
+]
+```
+
+## Use Mongo Seeding
+
+> **NOTE:** You can import data using any Mongo Seeding tool. This example shows Mongo Seeding CLI usage.
+
+The following example imports data from `./mongoose-express/data` directory using MongoDB connection URI `mongodb://127.0.0.1:27017/mydb` with option to drop database before import:
+
+```bash
+seed -u mongodb://127.0.0.1:27017/mydb --drop-database ./data
+```
+
+To specify custom parameters, see the [Command Line Parameters](../../cli/README.md#command-line-parameters) section in Mongo Seeding CLI Readme.
+Once the database seed finishes, the database is populated with collections from `./data` directory.
+
+## Create Express.js application
+
+To create application which exposes HTTP API, use Express.js. To bring the defined relation of customers, menus, and orders, use the [populate](https://mongoosejs.com/docs/populate.html) function of Mongoose.
+
+Create the following file:
+
+**index.js**
+
+```js
+const express = require('express');
+const mongoose = require('mongoose');
+const bodyParser = require('body-parser');
+const port = process.env.PORT || 3000;
+const Order = require('./models/order');
+const app = express();
+
+const api = express.Router();
+
+api.get('/orders', (req, res) => {
+  Order.find()
+    .populate('order_detail customer')
+    .exec(function (err, order) {
+      if (err) return res.status(500).send(err);
+
+      res.status(200).send(order);
+    });
+});
+
+app.use(bodyParser.urlencoded({ extended: false }));
+app.use(bodyParser.json());
+app.use(`/`, api);
+
+mongoose.connect(
+  `mongodb://localhost:27017/mydb`,
+  { useNewUrlParser: true, useUnifiedTopology: true, useCreateIndex: true },
+  (err, res) => {
+    if (err) {
+      throw err;
+    } else {
+      app.listen(port, () => {
+        console.log(`Server is running on http://localhost:${port}`);
+      });
+    }
+  },
+);
+```
+
+## Run application
+
+> **NOTE:** Before running the application, ensure the MongoDB instance is running.
+
+To run the application, run the following command:
+
+```bash
+npm start
+```
+
+To test the API, run the following command:
+
+```bash
+curl 'http://localhost:3000/orders'
+```
+
+The response is:
+
+```json
+[
+  {
+    "order_detail": [
+      {
+        "category": "mainCourse",
+        "_id": "5e606408dc8aec3040688a86",
+        "name": "Lomo saltado",
+        "price": 20
+      },
+      {
+        "category": "firstCourse",
+        "_id": "5e6066bea0403411bc4a3333",
+        "name": "Ceviche",
+        "price": 18
+      }
+    ],
+    "_id": "5e8186aa5d750a38e4260fcc",
+    "customer": {
+      "_id": "5e8508ea69a10e42d07414be",
+      "name": "Emma",
+      "lastname": "Watson",
+      "email": "emma@watson.com",
+      "password": "$2a$10$hhn8vSvl6rpv42undbkQ.O5XIdIJkujyqQWqKIxRJgLQYCGlM/6rW"
+    },
+    "date": "2020-03-11T05:00:00.000Z"
+  },
+  {
+    "order_detail": [
+      {
+        "category": "mainCourse",
+        "_id": "5e60650ea0403411bc4a332f",
+        "name": "Stew",
+        "price": 20
+      },
+      {
+        "category": "firstCourse",
+        "_id": "5e6066e9a0403411bc4a3334",
+        "name": "Tacos",
+        "price": 18
+      }
+    ],
+    "_id": "5e8187d53eda1f3a20d887e1",
+    "customer": {
+      "_id": "5e850bd669a10e42d07414c0",
+      "name": "Pablo",
+      "lastname": "Picasso",
+      "email": "pablo@picasso.com",
+      "password": "$2a$10$hhn8vSvl6rpv42undbkQ.O5XIdIJkujyqQWqKIxRJgLQYCGlM/6rW"
+    },
+    "date": "2020-03-11T05:00:00.000Z"
+  }
+]
+```

--- a/hack/assistant-setup/content-custom/import-data-definition.md
+++ b/hack/assistant-setup/content-custom/import-data-definition.md
@@ -1,0 +1,117 @@
+# Import data definition guide
+
+This guide describes how to define the data for seeding your MongoDB database.
+
+## Create proper directory structure
+
+1. Create a new directory for your data. In this tutorial, it is named simply as `data`.
+1. Navigate to the newly created directory.
+1. Create subdirectories. Every directory in `data` folder represents a single MongoDB collection.
+
+   - If you don't want to set the import order, put collection name in the directory name, e.g. `categories`, `posts`, `comments`, etc.
+   - To define a custom import order, follow the directory naming convention: `{order-number}{separator}{collection-name}`, for example `1-categories`, `2_posts` `3.comments`, `4 tags`, etc. Supported separators are the following characters: `-`, `_`, `.` and space.
+   - Collection is created in database if it contains at least one MongoDB Document definition.
+   - If you mix two approaches: unordered and ordered import, collections with unspecified import order number are always imported last.
+
+1. Create JSON, JavaScript or TypeScript files in every directory that represents MongoDB collection. The collection directory can contain multiple files with different extensions (`json`, `js`, 'cjs', or `ts`). In these files export single object or array of objects. Every object represents one MongoDB document.
+
+   - In JavaScript files (`js` extension), use `module.exports = objectOrArray`.
+
+     **Single object**
+
+     ```javascript
+     module.exports = {
+       name: 'Parrot',
+     };
+     ```
+
+     **Array of objects**
+
+     ```javascript
+     module.exports = [
+       {
+         name: 'Dog',
+       },
+       {
+         name: 'Cat',
+       },
+     ];
+     ```
+
+   - In TypeScript files (`ts` extension), use `export = objectOrArray`.
+
+     **Single object**
+
+     ```typescript
+     export = {
+       name: 'Parrot',
+     };
+     ```
+
+     **Array of objects**
+
+     ```typescript
+     export = [
+       {
+         name: 'Dog',
+       },
+       {
+         name: 'Cat',
+       },
+     ];
+     ```
+
+     > **Note:** TypeScript files are supported in Mongo Seeding CLI and Mongo Seeding Docker image. You can utilize static type checking in your custom app with Mongo Seeding library, but you have to include TypeScript runtime and then enable `ts` support in configuration.
+
+   - In JSON files (`json` extension), define single objects or array of objects. [Extended JSON](https://docs.mongodb.com/manual/reference/mongodb-extended-json) syntax is also supported.
+
+     **Single object**
+
+     ```json
+     {
+       "name": "Penguin"
+     }
+     ```
+
+     **Array of objects**
+
+     ```json
+     [
+       {
+         "name": "Hamster"
+       },
+       {
+         "name": "Crocodile"
+       }
+     ]
+     ```
+
+1. The following example visualizes the complete file structure of import data:
+
+   ```
+   .
+   ├── data // Root directory
+   │    ├── 1-categories // `categories` collection
+   │    │   ├── cat.js
+   │    │   ├── dogs.js
+   │    │   └── other-animals.json
+   │    ├── 2-posts // `posts` collection
+   │    │   ├── post-about-my-cat.json
+   │    │   ├── dog-posts.js
+   │    │   └── random-stuff.ts
+   │    └── 3-media // `media` collection
+   │        ├── cat-image.ts
+   │        └── dog.js
+   ```
+
+## Use TypeScript or JavaScript over JSON data definition
+
+Instead of using JSON files, the recommended way is to define the import data in JavaScript ones. In this approach you can use all the benefits of JavaScript, like external library import or your own helper functions. Remember to define helpers in other directory that the one with import data! We don't want to try importing them, right?
+
+Even better is to use TypeScript. You gain the static validation of import data models. Remember to define models in other directory that the one with import data.
+
+To read more about JavaScript and TypeScript benefits, see the [Motivation](../README.md#motivation) paragraph in the main Readme document.
+
+## See examples
+
+To see complete, ready to import sample data, navigate to [Examples](../examples) directory.

--- a/hack/assistant-setup/content-custom/readme.md
+++ b/hack/assistant-setup/content-custom/readme.md
@@ -1,0 +1,194 @@
+![Mongo Seeding](https://raw.githubusercontent.com/pkosiec/mongo-seeding/main/docs/assets/logo.png)
+
+# Mongo Seeding
+
+[![GitHub release](https://img.shields.io/github/release/pkosiec/mongo-seeding.svg)](https://github.com/pkosiec/mongo-seeding/releases) [![Build Status](https://github.com/pkosiec/mongo-seeding/actions/workflows/branch.yaml/badge.svg)](https://github.com/pkosiec/mongo-seeding/actions) [![MIT license](https://img.shields.io/badge/License-MIT-blue.svg)](https://lbesson.mit-license.org/)
+
+The ultimate solution for populating your MongoDB database :rocket:
+
+Define MongoDB documents in JSON, JavaScript or even TypeScript files. Use JS library, install CLI or run Docker image to import them!
+
+## Introduction
+
+Mongo Seeding is a flexible set of tools for importing data into MongoDB database.
+
+It's great for:
+
+- testing database queries, automatically or manually
+- preparing ready-to-go development environment for your application
+- setting initial state for your application
+
+## How does it work?
+
+1. Define documents for MongoDB import in JSON, JavaScript or TypeScript file(s). To learn, how to do that, read the **[import data definition](./docs/import-data-definition.md)** guide. To see some examples, navigate to the **[`examples`](./examples)** directory.
+
+1. Use one of the Mongo Seeding tools, depending on your needs:
+
+   - [TypeScript/JavaScript library with friendly API](./core)
+   - [Command line interface (CLI)](./cli)
+   - [Docker image](./docker-image)
+
+1. ???
+1. Profit!
+
+## Motivation
+
+There are many tools for MongoDB data import out there, including the official one - `mongoimport`. Why should you choose Mongo Seeding?
+
+### Problem #1: JSON used for import data definition
+
+Every tool I found before creating Mongo Seeding support only JSON files. In my opinion, that is not the most convenient way of data definition. The biggest problems are data redundancy and lack of ability to write logic.
+
+Imagine that you want to import 10 very similar documents into `authors` collection. Every document is identical - except the name:
+
+```json
+{
+  "name": "{NAME_HERE}",
+  "email": "example@example.com",
+  "avatar": "https://placekitten.com/300/300"
+}
+```
+
+With every tool I've ever found, you would need to create 5 separate JSON files, or one file with array of objects. Of course, the latter option is better, but anyway you end up with a file looking like this:
+
+```json
+[
+  {
+    "name": "John",
+    "email": "example@example.com",
+    "avatar": "https://placekitten.com/300/300"
+  },
+  {
+    "name": "Joanne",
+    "email": "example@example.com",
+    "avatar": "https://placekitten.com/300/300"
+  },
+  {
+    "name": "Bob",
+    "email": "example@example.com",
+    "avatar": "https://placekitten.com/300/300"
+  },
+  {
+    "name": "Will",
+    "email": "example@example.com",
+    "avatar": "https://placekitten.com/300/300"
+  },
+  {
+    "name": "Chris",
+    "email": "example@example.com",
+    "avatar": "https://placekitten.com/300/300"
+  }
+]
+```
+
+It doesn't look good - you did probably hear about [DRY](https://en.wikipedia.org/wiki/Don%27t_repeat_yourself) principle.
+
+Imagine that now you have to change authors' email. You would probably use search and replace. But what if you would need change the data shape completely? This time you can also use IDE features like multiple cursors etc., but hey - it's a waste of time. What if you had a much more complicated data shape?
+
+If you could use JavaScript to define the authors documents, it would be much easier and faster to write something like this:
+
+```javascript
+const names = ['John', 'Joanne', 'Bob', 'Will', 'Chris'];
+
+module.exports = names.map((name) => ({
+  name,
+  email: 'example@example.com',
+  avatar: 'https://placekitten.com/300/300',
+}));
+```
+
+Obviously, in JavaScript files you can also import other files - external libraries, helper methods etc. It's easy to write some data randomization rules - which are mostly essential for creating development sample data. Consider the following example of `people` collection import:
+
+```javascript
+const { getObjectId } = require('../../helpers/index');
+
+const names = ['John', 'Joanne', 'Bob', 'Will', 'Chris'];
+
+const min = 18;
+const max = 100;
+
+module.exports = names.map((name) => ({
+  firstName: name,
+  age: Math.floor(Math.random() * (max - min + 1)) + min,
+  _id: getObjectId(name),
+}));
+```
+
+The difference should be noticeable. This way of defining import data feels just right. And yes, you can do that in Mongo Seeding. But, JSON files are supported as well.
+
+### Problem #2: No data model validation
+
+In multiple JSON files which contains MongoDB documents definition, it's easy to make a mistake, especially in complex data structure. Sometimes a typo results in invalid data. See the example below for `people` collection definition:
+
+```json
+[
+  {
+    "name": "John",
+    "email": "john@mail.de",
+    "age": 18
+  },
+  {
+    "name": "Bob",
+    "email": "bob@example.com",
+    "age": "none"
+  }
+]
+```
+
+Because of a typo, Bob has `email` field empty. Also, there is a non-number value for `age` key.
+The same problem would exist in JavaScript data definition. But, if you were able to use TypeScript, the situation slightly changes:
+
+```typescript
+export interface Person {
+  name: string;
+  email: string;
+  age: number;
+}
+```
+
+```typescript
+// import interface defined above
+import { Person } from '../../models/index';
+
+const people: Person[] = [
+  {
+    name: 'John',
+    email: 'john@mail.de',
+    age: 18,
+  },
+  {
+    name: 'Bob',
+    emial: 'bob@example.com', // <-- error underlined in IDE
+    age: 'none', //  <-- error underlined in IDE
+  },
+];
+
+export = people;
+```
+
+If you used types, you would instantly see that you made mistakes - not only during import, but much earlier, in your IDE.
+
+At this point some can say: “We had this for years — this is the purpose of mongoose!”. The problem is that importing a bigger amount of data with mongoose is painfully slow — because of the model validation. You can decide to use a faster approach, `Model.collection.insert()`
+method, but in this case you disable model validation completely!
+
+Also, starting from version 3.6, MongoDB supports JSON Schema validation. Even if you are OK with writing validation rules in JSON, you still have to try inserting a document into collection to see if the object is valid. It is too slow and cumbersome, isn’t it? How to solve this problem?
+
+It’s simple. Use TypeScript. Compile time model validation will be much faster. And IDE plugins (or built-in support like in Visual Studio Code) will ensure that you won’t make any mistake during sample data file modification. Oh, and the last thing: If you have an existing TypeScript application which uses MongoDB, then you can just reuse all models for data import.
+
+The Mongo Seeding CLI and Mongo Seeding Docker Image have TypeScript runtime built-in. It means that you can take advantage of static type checking in TypeScript data definition files (`.ts` extension).
+
+### Problem #3: No ultimate solution
+
+Tools like this should be as flexible as possible. Some developers need just CLI tool, and some want to import data programmatically. Before writing Mongo Seeding, I needed a ready-to-use Docker image and found none. Dockerizing an application is easy, but it takes time.
+
+That's why Mongo Seeding consists of:
+
+- [TypeScript/JavaScript library](./core) - it can be installed straight from NPM and used in any JavaScript/TypeScript project,
+- [Command line interface (CLI)](./cli) - it can be installed globally and used from command line in any location,
+- [Docker image](./docker-image) - it is good for containerized applications.
+
+All tools you'll ever need for seeding your MongoDB database.
+
+## Contribution
+
+Before you contribute to this project, read **[`CONTRIBUTING.md`](./CONTRIBUTING.md)** file.

--- a/internal/source/ai-brain/assistant.go
+++ b/internal/source/ai-brain/assistant.go
@@ -275,10 +275,19 @@ func (i *assistant) createNewThread(ctx context.Context, p *Payload) (openai.Thr
 	ctx, span := i.tracer.Start(ctx, "aibrain.assistant.createNewThread")
 	defer span.End()
 
+	i.log.Info("Creating a new thread with vector store attached")
+
 	return i.openaiClient.CreateThread(ctx, openai.ThreadRequest{
 		Metadata: map[string]any{
 			"messageId":  p.MessageID,
 			"instanceId": os.Getenv(remote.ProviderIdentifierEnvKey),
+		},
+		ToolResources: openai.ToolResourcesRequest{
+			FileSearch: &openai.FileSearchToolResourcesRequest{
+				VectorStoreIDs: []string{
+					"vs_RrDoGGJ4UVLZxOvNzc5J1Unk", // fixed custom vector store with Mongo Seeding docs
+				},
+			},
 		},
 		Messages: []openai.ThreadMessage{
 			{

--- a/internal/source/ai-brain/tool_calls.go
+++ b/internal/source/ai-brain/tool_calls.go
@@ -10,7 +10,7 @@ import (
 
 // https://platform.openai.com/docs/api-reference/runs/object#runs/object-tools
 var userFriendlyToolNames = map[string]string{
-	"file_search": "Botkube content search", // for now it is only that, later when we will have the "Bring your own docs" functionality, we should rename it
+	"file_search": "Botkube & custom content search",
 
 	"function/botkubeGetStartupAgentConfiguration": "Botkube agent configuration",
 	"function/botkubeGetAgentStatus":               "Botkube agent status",


### PR DESCRIPTION
<!-- Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

## Description

Changes proposed in this pull request:

- Create PoC for a custom vector store

**This PR won't be merged.**

## Description

This PR documents the changes needed to support custom user documentation. What I did:

1.  Configured my own assistant with Botkube content vector store.
   - Almost 1:1 dev Assistant copy, but I've modified the instructions with "The custom user documentation is stored in a vector store."

1. Uploaded documentation of the https://github.com/pkosiec/mongo-seeding to another vector store.
1. [Contributed to the go-openai library](https://github.com/sashabaranov/go-openai/pull/760) to support referring to a vector store from a thread.
1. Attached the Mongo Seeding vector store to the thread.
1. Ran Botkube with local Botkube Cloud configured with the modified AI plugin.

You can use my `asst_EOOt8PiAy1boLPMTrFPdalHg` assistant to test the functionality.


## Video

https://github.com/kubeshop/botkube-cloud-plugins/assets/7155799/53959df0-fc2e-40a4-8eef-5dd9ad2d6436

## Slack thread link

https://temptestworkspaceco.slack.com/archives/C05S247ENER/p1716974853873029

## Related issue(s)

https://github.com/kubeshop/botkube-cloud/issues/1087
